### PR TITLE
Add docker info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,31 @@ may not want to allocate static IPs to your application instances. In other situ
 egress proxy layer, you only need to assign static IPs to your proxy instances.
 
 ## Getting Started
+
+Webhook Sentry runs on port 9090 by default. You can configure the address and port in the `listeners` section of the [config](#Configuration).
+
+The simplest way to run Webhook Sentry is to use the latest binary:
+
 1. Download the [latest release](https://github.com/juggernaut/webhook-sentry/releases/latest) for your platform
 2. Run the downloaded binary:
 ```
 whsentry
 ```
 
-Webhook Sentry runs on port 9090 by default. You can configure the address and port in the `listeners` section of the [config](#Configuration).
+We also have a docker image:
+
+```
+docker run juggernaut/webhook-sentry:latest
+```
+
+You can also pin a [tagged release](https://github.com/juggernaut/webhook-sentry/releases):
+
+```
+docker run juggernaut/webhook-sentry:v1.0.8
+```
+
+If you need to override settings, you can mount a settings file into your docker image.
+
 
 ## Usage
 ### HTTP target


### PR DESCRIPTION
Nothing revolutionary in here, I think.

One thing to mention is that these docs say that configs in docker must be overridden by mounting a config file. That's fine for us, since we don't need to override anything, but others may want to figure out how to override using envs instead. We looked at landing that too, but we're not go devs, so it seemed difficult. A problem for another day, in any case! 

Thank you again. We are deploying this at [Free Law Project](https://free.law/), a non-profit that uses code and advocacy to make the legal system better. We have a Slack if you might be interested in volunteering. I'm sure we could use your expertise!