### PR TITLE
Fix prometheus metrics so they're exposed properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ COPY . ./
 
 RUN go build -o /webhook-sentry
 EXPOSE 9090
+EXPOSE 2112
 CMD /webhook-sentry

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -45,7 +45,7 @@ accessLog:
   type: text
 proxyLog:
   type: text
-metricsAddress: 127.0.0.1:2112
+metricsAddress: ":2112"
 requestIDHeader: Request-ID
 `
 


### PR DESCRIPTION
I spent some today trying to understand go, and I think I sort of succeeded. There are two very small changes here:

1. **Port 2112 needs to be exposed from the docker image.** 

    If this isn't the case, you can't connect to the prometheus stats, so I tweaked the Dockerfile to add that port. Easy stuff once you know it's needed. Without this, you can't connect to docker on port 2112 and you get sad trying.

4. **The default `metricsAddress` should not include the host.** 

    Before I did this, I wasn't able to connect to the metrics server at `/metrics`. After this change, it worked, so I think this is a needed fix. I only figured this out via trial and error because I'm not good at go and don't even know how to look this up, but it did seem to make it work.

With this in place, I think this fixes #9 too, because you can now launch docker with:

```
docker run -p 9090:9090 -p 2112:2112 mlissner/webhook-sentry:latest
```

And then you can get the prometheus metrics with a 200 OK status code:

```
curl localhost:2112/metrics
# HELP current_inbound_connections The number of current inbound proxy connections
# TYPE current_inbound_connections gauge
current_inbound_connections{listener=":9090"} 0
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
go_gc_duration_seconds{quantile="0.5"} 0
go_gc_duration_seconds{quantile="0.75"} 0
go_gc_duration_seconds{quantile="1"} 0
go_gc_duration_seconds_sum 0
go_gc_duration_seconds_count 0
[...goes on awhile...]
```

Once this and #10 are merged, I'll try to remember to do a PR to update the docs to include how to get prometheus metrics (mainly, you just have to have the port open and go to `/metrics`).